### PR TITLE
Disable Elder Guardian Mining Fatigue

### DIFF
--- a/patches/server/0022-Monumenta-Disable-Elder-Guardian-Mining-Fatigue.patch
+++ b/patches/server/0022-Monumenta-Disable-Elder-Guardian-Mining-Fatigue.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joel Ong <ongjiaming2001@gmail.com>
+Date: Sat, 18 Jun 2022 20:13:36 +1000
+Subject: [PATCH] Monumenta - Disable Elder Guardian Mining Fatigue
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java b/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
+index ee9194ffb3cc6d660d4f99a3914ede7e4a3643fe..fd0d3721bffefbf08f8234130352cfa2d4020a26 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
++++ b/src/main/java/net/minecraft/world/entity/monster/ElderGuardian.java
+@@ -64,6 +64,7 @@ public class ElderGuardian extends Guardian {
+         super.customServerAiStep();
+         boolean flag = true;
+ 
++        /* MONUMENTA - Get rid of vanilla Elder Guardian Mining Fatigue
+         if ((this.tickCount + this.getId()) % 1200 == 0) {
+             MobEffect mobeffectlist = MobEffects.DIG_SLOWDOWN;
+             List<ServerPlayer> list = ((ServerLevel) this.level).getPlayers((entityplayer) -> {
+@@ -84,7 +85,7 @@ public class ElderGuardian extends Guardian {
+                 }
+                 } // Paper - Add Guardian Appearance Event
+             }
+-        }
++        } */
+ 
+         if (!this.hasRestriction()) {
+             this.restrictTo(this.blockPosition(), 16);


### PR DESCRIPTION
Commented out the code that causes Elder Guardians to give mining fatigue (and the jump scare) to the player.